### PR TITLE
Adds prefix for tracking changes to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 | B | Bug | 
 | !!! | non-provable refactoring | 
 | c | comments (add/delete) | 
+| d | developer documentation changes (not end-user facing) |
 | e | environment (non-code) changes | 
 | t | Test only | 
 | r | Provable Refactoring | 


### PR DESCRIPTION
This is meant to track changes to files such as `README*` or anything that might appear in a `docs` folder. The intent is to use this prefix for documentation changes which have absolutely no effect on the output of the code. It should not be used for making changes to any documentation that is rendered to a user of code in question. For example changes to the output produced by running `--help` for a console application *should not* use this prefix. An upper-case prefix should be used for such changes.