### PR TITLE
fix: Update the .gitmessage template with a pedantic nitpick

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,7 +1,7 @@
 
 #@ F Enable snarzle bifurcation
 # \ \ \
-#  \ \ Commit message
+#  \ \ Commit Summary
 #   \ Change Type
 #    Risk Level
 #


### PR DESCRIPTION
"Commit message" -> "Commit Summary"

The "commit message" includes everything, not just the first line (since `git commit --message "..."` covers everything.

In the main README we refer to the first line as the summary:

> This information is conveyed in the first 3 characters of the commit summary line.

A possible alternative would be "Commit Description", since the first three characters of the first line are also part of the summary.